### PR TITLE
Fixed object checking bug and removed lodash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 module.exports = formatKeys;
 
 /**
- * Format input keys recursively.
- *
- * @param {Object} input
- * @param {Function} formatter
- * @returns {Object}
- */
+* Format input keys recursively.
+*
+* @param {Object} input
+* @param {Function} formatter
+* @returns {Object}
+*/
 
 function formatKeys(input, formatter) {
   if (!input || typeof input !== 'object') {
@@ -15,6 +15,7 @@ function formatKeys(input, formatter) {
   if (typeof formatter !== 'function') {
     throw new Error('formatter is not a function');
   }
+
 
   if (Array.isArray(input)) {
     return input.map(function(val) {
@@ -29,6 +30,9 @@ function formatKeys(input, formatter) {
   }, {});
 }
 
+// check val isn't null, is an object, and is not an object represented by a string (i.e. Date)
 function formatIfObject(val, formatter) {
-  return val && typeof val === 'object' ? formatKeys(val, formatter) : val;
+  var parsed = JSON.parse(JSON.stringify(val));
+  var shouldFormat = val && typeof parsed === 'object';
+  return shouldFormat ? formatKeys(val, formatter) : val;
 }

--- a/index.js
+++ b/index.js
@@ -1,29 +1,34 @@
-var _ = require('lodash');
-
-/**
- * Expose module.
- */
-
 module.exports = formatKeys;
 
 /**
- * Format object keys recursively.
+ * Format input keys recursively.
  *
- * @param {Object} object
+ * @param {Object} input
  * @param {Function} formatter
  * @returns {Object}
  */
 
-function formatKeys(object, formatter) {
-  if (! Array.isArray(object) && ! _.isPlainObject(object)) return object;
+function formatKeys(input, formatter) {
+  if (!input || typeof input !== 'object') {
+    throw new Error('input is not an object literal or array');
+  }
+  if (typeof formatter !== 'function') {
+    throw new Error('formatter is not a function');
+  }
 
-  if (Array.isArray(object)) return _.map(object, function (val) {
-      return formatKeys(val, formatter);
+  if (Array.isArray(input)) {
+    return input.map(function(val) {
+      return formatIfObject(val, formatter);
     });
+  }
 
-  return Object.keys(object).reduce(function (mem, key) {
+  return Object.keys(input).reduce(function(mem, key) {
     var newKey = formatter(key);
-    mem[newKey] = formatKeys(object[key], formatter);
+    mem[newKey] = formatIfObject(input[key], formatter);
     return mem;
   }, {});
+}
+
+function formatIfObject(val, formatter) {
+  return typeof val === 'object' ? formatKeys(val, formatter) : val;
 }

--- a/index.js
+++ b/index.js
@@ -30,5 +30,5 @@ function formatKeys(input, formatter) {
 }
 
 function formatIfObject(val, formatter) {
-  return typeof val === 'object' ? formatKeys(val, formatter) : val;
+  return val && typeof val === 'object' ? formatKeys(val, formatter) : val;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-keys",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Format object keys recursively.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^1.18.2"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+
   }
 }

--- a/test.js
+++ b/test.js
@@ -37,4 +37,14 @@ describe('#formatKeys', function() {
     ]);
   });
 
+  // because `null` is an object
+  it('should not consider call itself internally on `null` values', function() {
+    var obj = {
+      foo: null
+    };
+    assert.doesNotThrow(function() {
+      formatKeys(obj, Function.call.bind(''.toUpperCase));
+    });
+  });
+
 });

--- a/test.js
+++ b/test.js
@@ -1,13 +1,40 @@
 var formatKeys = require('./index');
 var assert = require('assert');
 
-describe('#formatKeys', function () {
-  it('should format keys', function () {
-    var object = { foo: 'bar', deep: { kung: 'foo' }, ar: [{ foo: 'bar' }] };
-    var formattedObject = formatKeys(object, function upperCaseFormatter(str) {
-      return str.toUpperCase();
-    });
+describe('#formatKeys', function() {
 
+  it('should format keys for object', function () {
+    var object = { foo: 'bar', deep: { kung: 'foo' }, ar: [{ foo: 'bar' }] };
+    var formattedObject = formatKeys(object, Function.call.bind(''.toUpperCase));
     assert.deepEqual(formattedObject, { FOO: 'bar', DEEP: { KUNG: 'foo' }, AR: [{ FOO: 'bar' }] });
   });
+
+  it('should format keys for array of objects', function() {
+    var obj = [
+      {
+        foo: 'foo',
+        bar: 'bar',
+        baz: {
+          foo: 'foo'
+        }
+      },
+      {
+        foo: 'foo'
+      }
+    ];
+    var formatted = formatKeys(obj, Function.call.bind(''.toUpperCase));
+    assert.deepEqual(formatted, [
+      {
+        FOO: 'foo',
+        BAR: 'bar',
+        BAZ: {
+          FOO: 'foo'
+        }
+      },
+      {
+        FOO: 'foo'
+      }
+    ]);
+  });
+
 });

--- a/test.js
+++ b/test.js
@@ -47,4 +47,13 @@ describe('#formatKeys', function() {
     });
   });
 
+  it('should not mangle Date objects and the like', function() {
+    var d = new Date();
+    var obj = {
+      foo: d
+    };
+    var formatted = formatKeys(obj, Function.call.bind(''.toUpperCase));
+    assert.deepEqual({FOO: d}, formatted);
+  });
+
 });


### PR DESCRIPTION
The `.isPlainObject` check causes the function to unexpectedly not format an object. I was trying to use `formatKeys` on an object returned by `node-mysql` and it didn't pass the check. I fixed that bug, removed lodash as it is unnecessary, and added another test to ensure arrays are working as expected.
